### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
     - make install
 script:
     - cd test && make test
-    - cat test/Test_Error.dat
+    - cat Test_Error.dat

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,3 @@ install:
     - make install
 script:
     - cd test && make test
-    - cat Test_Error.dat

--- a/configure
+++ b/configure
@@ -8,7 +8,7 @@
 
 # Print help message
 Usage() {
-  echo "Usage: ./configure [gnu | intel | pgi] OPTIONS"
+  echo "Usage: ./configure [gnu | intel | clang | pgi] OPTIONS"
   echo "  OPTIONS:"
   echo "    --help     : Display this message."
   echo "    -d, -debug : Turn on compiler debugging info"
@@ -183,7 +183,7 @@ EOF
 
 #---------------------------------------------------------------------
 
-if [[ -z $1  || $1 = "--help" ]] ; then
+if [[ -z $1  || $1 = "--help" || $1 = "-h" ]] ; then
   Usage
   exit 0
 fi

--- a/test/MasterTest.sh
+++ b/test/MasterTest.sh
@@ -286,6 +286,13 @@ Summary() {
     echo "No Test Results files (./*/$TEST_RESULTS) found."
   fi
 
+  if [[ $ERR -gt 0 ]]; then
+    echo "Obtained the following errors:"
+    echo "---------------------------------------------------------"
+    cat $TEST_ERROR
+    echo "---------------------------------------------------------"
+  fi
+
   if [[ ! -z $VALGRIND ]] ; then
     RESULTFILES=`ls */$ERROR`
     if [[ ! -z $RESULTFILES ]] ; then
@@ -300,11 +307,11 @@ Summary() {
 #      echo "---------------------------------------------------------"
     else
       echo "No valgrind test results found."
-      exit 0
+      exit $ERR
     fi
   fi
   echo "========================================================="
-  exit 0
+  exit $ERR
 }
 
 #===============================================================================


### PR DESCRIPTION
This seems to have the desired effect for me on my machine.

Note that 2 of the test comparisons are currently failing, one of them because it seems like a test file was mistakenly omitted from the commit.  One of the lines from the `Test_Error.dat` output is:

```
  nofit.dat.save not found.
```

Also: `displ.dat.save displ.dat are different.`, and the differences look pretty serious...

This will fail the Travis build (or should fail it, anyway), but the problems should be fixed in a different PR.  These are only github-specific changes.