### PR TITLE
CPPTRAJ HN: add Box& in Topology to inplace update Topology.box in pytraj

### DIFF
--- a/src/CoordinateInfo.h
+++ b/src/CoordinateInfo.h
@@ -18,6 +18,7 @@ class CoordinateInfo {
       remdDim_(r), box_(b), ensembleSize_(e), hasVel_(v), hasTemp_(t), hasTime_(m), hasFrc_(f) {}
     bool HasBox()              const { return box_.HasBox();            }
     const Box& TrajBox()       const { return box_;                     }
+    Box& TrajBox()                   { return box_;                     }
     int EnsembleSize()         const { return ensembleSize_;            }
     bool HasVel()              const { return hasVel_;                  }
     bool HasTemp()             const { return hasTemp_;                 }

--- a/src/Frame.h
+++ b/src/Frame.h
@@ -85,6 +85,7 @@ class Frame {
     double Mass(int atnum)            const { return Mass_[atnum];   }
     /// \return Box information
     const Box& BoxCrd()               const { return box_;           }
+    Box&  BoxCrd()                          { return box_;           }
     RemdIdxType const& RemdIndices()  const { return remd_indices_;  }
     // Routines for accessing internal data pointers
     inline double* xAddress() { return X_;                }

--- a/src/Topology.h
+++ b/src/Topology.h
@@ -123,6 +123,7 @@ class Topology {
     int PrintChargeMassInfo(std::string const&, int) const;
     // ----- Routines to Access/Modify Box info --
     inline Box const& ParmBox()   const { return coordInfo_.TrajBox();        }
+    inline Box& ParmBox()               { return coordInfo_.TrajBox();        }
     inline Box::BoxType BoxType() const { return coordInfo_.TrajBox().Type(); }
     void SetParmBox( Box const& bIn )   { coordInfo_.SetBox( bIn );           }
     // ----- Setup routines ----------------------


### PR DESCRIPTION
Motivation: with current implementation of `cpptraj`, `top.box` in `pytraj` will return a copy of Box.
If user accidentally uses `top.box[0] = 100.`, `top.box` is not updated.

`pytraj` code
```python
    property box:
        def __get__(self):
            cdef Box box = Box()
            box.thisptr[0] = self.thisptr.ParmBox()
            return box
```

Proposed new code in `pytraj` (with PR for `cpptraj` too)
```python
    property box:
        def __get__(self):
            cdef Box box = Box()
            box.thisptr = &self.thisptr.ParmBox()
            box.py_free_mem = False # create a `view`
            return box
```

**Note**: `thisptr` is pointer to cpptraj's Box object