### PR TITLE
pytraj: return reference for Topology for pytraj

### DIFF
--- a/src/DataSet_Coords.h
+++ b/src/DataSet_Coords.h
@@ -26,6 +26,7 @@ class DataSet_Coords : public DataSet {
     void SetTopology(Topology const&);
     /// \return topology associated with these COORDS.
     inline Topology const& Top() const { return top_; }
+    inline Topology& Top()             { return top_; }
   protected:
     // TODO: Make unsigned
     int numCrd_;    ///< Number of coordinates


### PR DESCRIPTION
if there is no reference returning, every time calling `traj.top`,
pytraj need to make a copy of Topology, which is quite expensive.

(may be I misunderstand this code)